### PR TITLE
Add unwritten standards from Farama Handbook, fix typos

### DIFF
--- a/_data/project_standards.yml
+++ b/_data/project_standards.yml
@@ -32,19 +32,29 @@
       standards:
         - name: <b>Be fully deterministic</b> when given a specific random seed, so that any result can be exactly reproduced (ignoring potential issues due to floating point arithmetic errors).
         - name: <b>Include explicit versioning</b> in environment and wrapper names in a format like "Pong-v5" to make it clear to researchers when results are from differently configured environments.
-        - name: <b>Support either Pickling or EZ Pickling for all environments</b>. So that environments can be saved for experiment reproduction and for environment vectorization
+        - name: <b>Support serialization for all environments via Pickle or EzPickle</b>. This allows environments to be saved for experiment reproduction and for environment vectorization.
+    - title: User Experience
+      standards:
+        - name: <b>Include rendering for all environments</b>. Pygame is preferable whenever possible. 
+        - name: <b>APIs should be user-friendly and enforce correct usage.</b> New users should be able to easily use APIs correctly without needing to dig through source code.
+        - name: <b>Warning and errors should be descriptive and helpful.</b> When something goes wrong, it should be as easy as possible to identify the problem. Python f-Strings and assert statements are encouraged to catch common errors. 
+    - title: Organization
+      standards:
+        - name: <b>Projects should serve a single purpose.</b> Ideally, standard APIs, utilities, environments and datasets should be split into separate repositories. This makes maintenance more managable and simplifies user experience.
+        - name: <b>Included environments should have scientific value and be commonly used.</b> Toy environments which do not have scientific value should be clearly specified as such.
+        - name: <b>External dependencies should be limited, and include only well-maintained projects.</b> If an external dependency stops being maintained, benchmarks can no longer be maintained long term.
     - title: Other
       standards:
         - name: <b>Use an MIT or similarly styled open source license</b> (Apache 2.0 is fine). Listing an open source license is needed to properly distribute free and open source software. We prefer MIT styled licenses as they let users use the software in any way they'd like, and this style has become ubiquitous across projects in this field.
         - name: <b>Pull documentation website information from environments directly</b> instead of mannually specifying it. This prevents human errors in transcribing information or forgetting to update it when it changes in the future.
 
 - type_name: Farama Standards
-  type_description: Specific standards we specifically have for projects inside Farama that generally don't apply to other projects
+  type_description: Specific standards we enforce for projects inside Farama that generally don't apply to other projects
   type_standards:
     - title: Farama Branding
       standards:
-        - name: <b>Have a logo in the same style as the other projects.</b> A nice logo is a small feature that makes projects more memorable and makes the whole space a little more inviting to interested new students. Since we list all the logos together, we try to make sure they match.
-        - name: <b>Have the documentation website be at <project>.farama.org.</b> Having everything under a single domain name makes things simple and consistent for users (and makes things a bit easier for us to manage).
+        - name: <b>Have a logo in the same style as the other projects.</b> A nice logo is a small feature that makes projects more memorable and makes the whole space a little more inviting to interested new users. Since we list all the logos together, we try to make sure they match.
+        - name: <b>Have a documentation website at [project].farama.org.</b> Having everything under a single domain name makes things simple and consistent for users (and makes things a bit easier for us to manage).
         - name: <b>Include the standard Farama code of conduct.</b> We believe that all members of our community should be respected. Additionally, listing a code of conduct under our projects is a requirement for some open source donations.
     - title: Security
       standards:
@@ -52,6 +62,7 @@
         - name: <b>Have maintainers with GitHub or PyPI permissions use TOTP based 2FA or better</b> (and secure passwords, emails addresses, etc.), to reduce the likelihood of supply chain security attacks involving any of our projects.
     - title: Other
       standards:
+        - name: <b>Use Farama Notifcations</b>. This allows us to add warnings after releases about issues that users of old versions need to be aware of.
         - name: <b>Include Google analytics</b> in all documentation websites, so we can see how popular they are and what users are doing on the websites.
         - name: <b>Link Farama donations page</b> from the repository README and the documentation website sidebar.
-        - name: <b>Use Farama Notifcations</b>. So that we can add warnings after releases about issues that users of old versions need to be aware of.
+    


### PR DESCRIPTION
This PR adds a couple of unwritten standards taken from the Farama Handbook, and fixes some wording/typos.