### PR TITLE
fix(projects.yml): fix the link to MPE2's documentation

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -156,7 +156,7 @@
 
 - name: MPE2
   github: https://github.com/Farama-Foundation/MPE2
-  website: https://a2perf.farama.org/
+  website: http://mpe2.farama.org
   desc: A set of communication oriented environments
   image: MPE2.svg
   type: incubating

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -156,7 +156,7 @@
 
 - name: MPE2
   github: https://github.com/Farama-Foundation/MPE2
-  website: http://mpe2.farama.org
+  website: https://mpe2.farama.org
   desc: A set of communication oriented environments
   image: MPE2.svg
   type: incubating


### PR DESCRIPTION
Closing #98 

In the documentation's header, the MPE2 button was pointing towards the A2Perf's documentation website.