### PR TITLE
Switch ViZDoom type to mature

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -128,4 +128,4 @@
   website: https://vizdoom.farama.org/
   desc: Reinforcement Learning environments based on the 1993 game Doom
   image: vizdoom.svg
-  type: incubating
+  type: mature


### PR DESCRIPTION
Following ViZDoom Mature Farama Release: https://github.com/Farama-Foundation/ViZDoom/releases/tag/1.3.0
This PR moves it from incubating to the mature category.