### PR TITLE
Update gemfile to suppress warnings for Ruby 3.4+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'jekyll-sitemap'
 gem 'jekyll-redirect-from'
 
 # The csv, base64, and bigdecimal libraries are not part of the default gems starting from Ruby 3.4.0.
-# Adding them to the Gemfile supress warnings about missing gems when running Jekyll with Ruby 3.4.0 or later.
+# Adding them to the Gemfile suppress warnings about missing gems when running Jekyll with Ruby 3.4.0 or later.
 gem 'csv'
 
 gem 'base64'

--- a/Gemfile
+++ b/Gemfile
@@ -35,3 +35,11 @@ gem 'jekyll-seo-tag'
 gem 'jekyll-sitemap'
 
 gem 'jekyll-redirect-from'
+
+# The csv, base64, and bigdecimal libraries are not part of the default gems starting from Ruby 3.4.0.
+# Adding them to the Gemfile supress warnings about missing gems when running Jekyll with Ruby 3.4.0 or later.
+gem 'csv'
+
+gem 'base64'
+
+gem 'bigdecimal'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,11 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    base64 (0.3.0)
+    bigdecimal (4.0.1)
     colorator (1.1.0)
     concurrent-ruby (1.1.10)
+    csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -68,21 +71,19 @@ GEM
       ffi (~> 1.9)
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thread_safe (0.3.6)
-    tzinfo (1.2.10)
-      thread_safe (~> 0.1)
-    tzinfo-data (1.2022.3)
-      tzinfo (>= 1.0.0)
     unicode-display_width (1.8.0)
-    wdm (0.1.1)
     webrick (1.7.0)
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-25
   x64-unknown
   x86_64-linux
 
 DEPENDENCIES
+  base64
+  bigdecimal
+  csv
   jekyll (~> 4.2.1)
   jekyll-feed (~> 0.12)
   jekyll-redirect-from


### PR DESCRIPTION
This PR adds csv, base64, and bigdecimal libraries are not part of the default gems starting from Ruby 3.4.0.
Without this `bundle exec jekyll serve` fails to start on my machine with Ruby 3.4.1 and throws a warning.