### PR TITLE
Fix CI: trim trailing whitespace in _data/team.yml

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -16,7 +16,7 @@
   image: ariel.jpg
   site: https://github.com/RedTachyon
 
-- name: Andreas Kallinteris 
+- name: Andreas Kallinteris
   role: Gymnasium Robotics and Gymnasium Maintainer
   affiliation: Technical University of Crete
   image: andreas.jpg


### PR DESCRIPTION
## Summary
- Remove trailing whitespace on the `Andreas Kallinteris` entry in `_data/team.yml` so the pre-commit `trailing-whitespace` hook passes.