### PR TITLE
Fix donations page copy and drop babyai from MiniGrid download counter

### DIFF
--- a/_includes/components/stats_card.html
+++ b/_includes/components/stats_card.html
@@ -195,7 +195,7 @@
             if (project == "Gymnasium" && (stat == "downloads" || stat == "repos_use")) {
                 oldProjects = ["gym"];
             } else if (project == "MiniGrid" && stat == "downloads") {
-                oldProjects = ["gym-minigrid", "babyai"];
+                oldProjects = ["gym-minigrid"];
             } else if (project == "MAgent2" && stat == "downloads") {
                 oldProjects = ["magent"];
             } else if (project == "MO-Gymnasium" && stat == "downloads") {

--- a/donations.html
+++ b/donations.html
@@ -14,8 +14,7 @@ title: Donations
                     <h1>
                         {{page.title}}
                     </h1>
-                    <h4 class="mb-1 mt-4 text-center">Donations are used to pay our developers maintain our libraries
-                        and develop new ones</h4>
+                    <h4 class="mb-1 mt-4 text-center">Donations are used to pay our developers, maintain our libraries, and develop new ones</h4>
                     <div class="row pt-3 gx-2 farama-donation-cards-container"
                         style="display: flex; flex-wrap:wrap; justify-content: center;">
                         {% for org in site.data.donate %}
@@ -56,8 +55,7 @@ title: Donations
                             {% endfor %}
                         </div>
                         <div class="mt-4" style="width: 150px; height: 2px; border: 1px solid"></div>
-                        <h4 class="my-4 text-center">We are a 501c3 nonprofit, meaning that donations are deductible on
-                            your taxes
+                        <h4 class="my-4 text-center">We are a 501c3 nonprofit, meaning that donations are generally deductible on your taxes
                         </h4>
                         <div class="mb-4" style="width: 150px; height: 2px; border: 1px solid"></div>
                     </div>

--- a/stats.html
+++ b/stats.html
@@ -211,7 +211,7 @@ title: Project Stats
             if (project == "Gymnasium" && (stat == "downloads" || stat == "repos_use")) {
                 oldProjects = ["gym"];
             } else if (project == "MiniGrid" && stat == "downloads") {
-                oldProjects = ["gym-minigrid", "babyai"];
+                oldProjects = ["gym-minigrid"];
             } else if (project == "MAgent2" && stat == "downloads") {
                 oldProjects = ["magent"];
             }


### PR DESCRIPTION
## Summary

- **`donations.html`** — tightened two header lines for clarity and accuracy:
  - Added missing commas to "Donations are used to pay our developers, maintain our libraries, and develop new ones".
  - Softened the tax-deductibility line to "donations are generally deductible on your taxes" (more accurate for a 501c3 — deductibility depends on the donor's situation).
- **`_includes/components/stats_card.html` and `stats.html`** — removed `babyai` from the list of deprecated projects whose downloads roll up into the MiniGrid counter on `/stats` and `/stats/installations`. The MiniGrid total now sums only `minigrid` + `gym-minigrid`.