### PR TITLE
Trim project standards subtitle

### DIFF
--- a/project_standards.html
+++ b/project_standards.html
@@ -1,6 +1,6 @@
 ---
 title: Project Standards
-subtitle: For a project under Farama to be listed as mature, it must comply with the following standards. We work to maintain these standards for our existing projects, and update new projects to meet them. These standards may evolve over time, and we'll publicly announce any major changes to them.
+subtitle: For a project under Farama to be listed as mature, it must comply with the following standards. We work to maintain these standards for our existing projects, and update new projects to meet them.
 ---
 
 <div class="container my-5">


### PR DESCRIPTION
## Summary

- Shorten the subtitle on `project_standards.html` by removing the trailing sentence about standards evolving over time and major changes being announced. The subtitle now ends after "...update new projects to meet them.", keeping the intro concise.

## Test plan

- [ ] Build/serve the site locally and confirm the Project Standards page renders with the shortened subtitle and no layout issues.