### PR TITLE
Correct HighwayEnv maintainer name to Jin Huang

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -52,7 +52,7 @@
   image: lucas.jpg
   site: https://github.com/LucasAlegre
 
-- name: Jin Cheng
+- name: Jin Huang
   role: HighwayEnv Maintainer
   affiliation: University of Edinburgh
   image: jin.jpg


### PR DESCRIPTION
## Summary

- Fix the HighwayEnv maintainer's name in `_data/team.yml` from "Jin Cheng" to "Jin Huang". PR #109 introduced the entry with an incorrect first name; this corrects it while leaving the role, affiliation, and image unchanged.

## Test plan

- [ ] Confirm `_data/team.yml` lists the HighwayEnv Maintainer as "Jin Huang".
- [ ] Build/serve the site and verify the team page renders the corrected name with the existing `jin.jpg` image and University of Edinburgh affiliation.