### PR TITLE
List Mark Towers as a Shimmy maintainer

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -5,7 +5,7 @@
   site: https://jkterry.ai
 
 - name: Mark Towers
-  role: Gymnasium and Arcade Learning Environment Maintainer
+  role: Gymnasium, Arcade Learning Environment and Shimmy Maintainer
   affiliation: Anyscale
   image: mark.jpg
   site: https://github.com/pseudo-rnd-thoughts


### PR DESCRIPTION
Adds Shimmy to Mark Towers' maintainer role on the team page (`_data/team.yml`), so the team listing reflects that he maintains Shimmy alongside Gymnasium and the Arcade Learning Environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)