### PR TITLE
Add Marek Wydmuch as a PyPI owner in project standards

### DIFF
--- a/_data/project_standards.yml
+++ b/_data/project_standards.yml
@@ -73,7 +73,7 @@
     - title: Security
       standards:
         - name: "<b>Verify and sign commits with GPG or SSH keys.</b> This ensures commits are from trusted sources, and prevents potential attacks through spoofed identity."
-        - name: "<b>List Jordan Terry and Mark Towers as owners on PyPI</b>, to make sure that we don't lose control of a package in the case that a primary maintainer becomes unavailable due to unexpected circumstances."
+        - name: "<b>List Jordan Terry, Mark Towers and Marek Wydmuch as owners on PyPI</b>, to make sure that we don't lose control of a package in the case that a primary maintainer becomes unavailable due to unexpected circumstances."
         - name: "<b>Have maintainers with GitHub or PyPI permissions use TOTP based 2FA or better</b> (and secure passwords, emails addresses, etc.), to reduce the likelihood of supply chain security attacks involving any of our projects."
     - title: Other
       standards:


### PR DESCRIPTION
Updates the Security standard on the project standards page to list Marek Wydmuch as a PyPI package owner alongside Jordan Terry and Mark Towers, reflecting the current set of owners kept for continuity if a primary maintainer becomes unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)