### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scrape_stats.yml
+++ b/.github/workflows/scrape_stats.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: write
+
 jobs:
   scrape_stats_schedule:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/farama.org/security/code-scanning/1](https://github.com/Farama-Foundation/farama.org/security/code-scanning/1)

Add an explicit `permissions` block to the workflow (or job) so token scope is declared and minimized.  
Best fix without changing behavior: define permissions at the workflow root with `contents: write`, since this workflow has one job that must push commits. This both resolves the CodeQL finding and preserves current functionality.

Change needed in `.github/workflows/scrape_stats.yml`:
- Insert a root-level `permissions:` block between `on:` and `jobs:`
- Set:
  - `contents: write`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
