### PR TITLE
Update team page maintainers

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -23,16 +23,10 @@
   site: https://github.com/Kallinteris-Andreas
 
 - name: Reginald McLean
-  role: Metaworld Maintainer
+  role: Metaworld and Procgen2 Maintainer
   affiliation: Alberta Machine Intelligence Institute
   image: reginald.jpg
   site: https://github.com/reginald-mclean
-
-- name: Florian Felten
-  role: MO-Gymnasium and MOMAland Maintainer
-  affiliation: SnT, University of Luxembourg
-  image: florian.jpg
-  site: https://github.com/ffelten
 
 - name: Bolun Dai
   role: General Contributor


### PR DESCRIPTION
Updates `_data/team.yml`:

- Removes the entry for Florian Felten (previously listed as MO-Gymnasium and MOMAland Maintainer).
- Updates Reginald McLean's role from `Metaworld Maintainer` to `Metaworld and Procgen2 Maintainer`.

Note: `assets/people/florian.jpg` is left in place — it is now unreferenced by `team.yml`, so it can be pruned separately if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)