### PR TITLE
Remove MiniWoB++ from the projects list

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -51,14 +51,6 @@
   type: mature
   popular: true
 
-- name: MiniWoB++
-  github: https://github.com/Farama-Foundation/miniwob-plusplus
-  website: https://miniwob.farama.org/
-  desc: A collection of reinforcement learning environments for simple web interaction tasks
-  image: miniwobplusplus.svg
-  type: mature
-  pip: miniwob
-
 - name: MOMAland
   github: https://github.com/Farama-Foundation/momaland
   website: https://momaland.farama.org/


### PR DESCRIPTION
Removes the MiniWoB++ entry from `_data/projects.yml`, so it no longer appears on the projects page.

Left untouched deliberately:

- `assets/images/miniwobplusplus.svg` — now unreferenced, can be pruned separately if maintainers prefer.
- `_posts/2022-10-25-Announcing-The-Farama-Foundation.md` — mentions MiniWoB++ as a historical record of the 2022 announcement.
- `_data/complete_stats.yml` — contains a `miniwob-plusplus` key, but that file is regenerated by the stats scrape job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)